### PR TITLE
Fixed the Qt warning cause by having no window title set.

### DIFF
--- a/src/voxeditor.cpp
+++ b/src/voxeditor.cpp
@@ -66,6 +66,7 @@ VoxelEditor::VoxelEditor(MainWindow * parent)
     rubberband = new QRubberBand(QRubberBand::Rectangle);
     rubberband->setWindowOpacity((qreal)0.5);
     rubberband->setWindowFlags(Qt::ToolTip);
+    set_window_file_path(this, "(Untitled)");
 }
 
 void VoxelEditor::load(const QString & filename)


### PR DESCRIPTION
When the editor window was created no title was set, thus getting the following Qt warning:

> The window title does not contain a '[*]' placeholder
